### PR TITLE
Added alife():objects() scripting function

### DIFF
--- a/code/SDK/include/luabind/iterator_pair_policy.hpp
+++ b/code/SDK/include/luabind/iterator_pair_policy.hpp
@@ -1,0 +1,94 @@
+
+
+
+#pragma once
+
+#include <luabind/config.hpp>
+#include <luabind/detail/policy.hpp>
+#include <luabind/detail/implicit_cast.hpp>
+#include <luabind/detail/convert_to_lua.hpp>
+
+namespace luabind { namespace detail 
+{
+	template<typename Iter>
+	struct iterator_pair_state
+	{
+		typedef iterator_pair_state<Iter> self_t;
+
+		static int step(lua_State* L)
+		{
+			self_t& state = *static_cast<self_t*>(lua_touserdata(L, lua_upvalueindex(1)));
+
+			if (state.start == state.end)
+			{
+				lua_pushnil(L);
+				return 1;
+			}
+			else
+			{
+				convert_to_lua(L, (*state.start).first);
+				convert_to_lua(L, (*state.start).second);
+				++state.start;
+				return 2;
+			}
+		}
+
+		iterator_pair_state(const Iter& s, const Iter& e)
+			: start(s)
+			, end(e)
+		{}
+
+		Iter start;
+		Iter end;
+	};
+
+	struct iterator_pair_converter
+	{
+		template<typename T>
+		void apply(lua_State* L, const T& c)
+		{
+			typedef typename T::const_iterator iter_t;
+			typedef iterator_pair_state<iter_t> state_t;
+
+			// note that this should be destructed, for now.. just hope that iterator
+			// is a pod
+			void* iter = lua_newuserdata(L, sizeof(state_t));
+			new (iter) state_t(c.begin(), c.end());
+			lua_pushcclosure(L, state_t::step, 1);
+		}
+
+		template<typename T>
+		void apply(lua_State* L, T& c)
+		{
+			typedef typename T::iterator iter_t;
+			typedef iterator_pair_state<iter_t> state_t;
+
+			// note that this should be destructed, for now.. just hope that iterator
+			// is a pod
+			void* iter = lua_newuserdata(L, sizeof(state_t));
+			new (iter) state_t(c.begin(), c.end());
+			lua_pushcclosure(L, state_t::step, 1);
+		}
+	};
+
+	struct iterator_pair_policy : conversion_policy<0>
+	{
+		static void precall(lua_State*, const index_map&) {}
+		static void postcall(lua_State*, const index_map&) {}
+
+		template<typename T, Direction>
+		struct generate_converter
+		{
+			typedef iterator_pair_converter type;
+		};
+	};
+
+}}
+
+namespace luabind
+{
+	namespace
+	{
+		detail::policy_cons<detail::iterator_pair_policy> return_stl_pair_iterator;
+	}
+}

--- a/code/engine.vc2008/xrGame/StdAfx.h
+++ b/code/engine.vc2008/xrGame/StdAfx.h
@@ -48,3 +48,4 @@ extern "C" {
 #include <luabind/return_reference_to_policy.hpp>
 #include <luabind/out_value_policy.hpp>
 #include <luabind/iterator_policy.hpp>
+#include <luabind/iterator_pair_policy.hpp>

--- a/code/engine.vc2008/xrGame/alife_simulator.cpp
+++ b/code/engine.vc2008/xrGame/alife_simulator.cpp
@@ -203,6 +203,12 @@ CSE_ALifeDynamicObject *alife_object(const CALifeSimulator *self, ALife::_OBJECT
 	return			(self->objects().object(id, no_assert));
 }
 
+const CALifeObjectRegistry::OBJECT_REGISTRY& alife_objects(const CALifeSimulator *self)
+{
+	VERIFY			(self);
+	return self->objects().objects();
+}
+
 CSE_ALifeDynamicObject *alife_story_object(const CALifeSimulator *self, ALife::_STORY_ID id)
 {
 	return			(self->story_objects().object(id, true));
@@ -451,6 +457,7 @@ void CALifeSimulator::script_register(lua_State *L)
 			.def("valid_object_id", &valid_object_id)
 		.def("level_id", &get_level_id)
 		.def("level_name", &get_level_name)
+		.def("objects", &alife_objects, return_stl_pair_iterator)
 		.def("object", (CSE_ALifeDynamicObject *(*) (const CALifeSimulator *, ALife::_OBJECT_ID))(alife_object))
 		.def("object", (CSE_ALifeDynamicObject *(*) (const CALifeSimulator *, ALife::_OBJECT_ID, bool))(alife_object))
 		.def("story_object", (CSE_ALifeDynamicObject *(*) (const CALifeSimulator *, ALife::_STORY_ID))(alife_story_object))


### PR DESCRIPTION
- Added alife():objects() scripting function to conveniently iterate over all alife objects (instead of bruteforcing ids...) 
- Added "iterator_pair_policy" for luabind (custom-made)

Use it like this (in Lua):

```
for id, obj in alife():objects() do
  ...
end
```
