### PR TITLE
Added 3rd parameter to hud motions - speed multiplier

### DIFF
--- a/code/engine.vc2008/xrGame/player_hud.cpp
+++ b/code/engine.vc2008/xrGame/player_hud.cpp
@@ -49,20 +49,28 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
 			pm						= &m_anims.back();
 			//base and alias name
 			pm->m_alias_name		= _b->first;
-			
+
 			if(_GetItemCount(anm.c_str())==1)
 			{
 				pm->m_base_name			= anm;
 				pm->m_additional_name	= anm;
+				pm->m_anim_speed		= 1.f;
 			}else
 			{
-				R_ASSERT2(_GetItemCount(anm.c_str())==2, anm.c_str());
+				R_ASSERT2(_GetItemCount(anm.c_str())<=3, anm.c_str());
 				string512				str_item;
 				_GetItem(anm.c_str(),0,str_item);
 				pm->m_base_name			= str_item;
 
 				_GetItem(anm.c_str(),1,str_item);
-				pm->m_additional_name	= str_item;
+				pm->m_additional_name = (strlen(str_item) > 0)
+					? pm->m_additional_name = str_item
+					: pm->m_base_name;
+
+				_GetItem(anm.c_str(),2,str_item);
+				pm->m_anim_speed = strlen(str_item) > 0
+					? atof(str_item)
+					: 1.f;
 			}
 
 			//and load all motions for it
@@ -310,8 +318,6 @@ void attachable_hud_item::load(const shared_str& sect_name)
 
 u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, const CMotionDef*& md, u8& rnd_idx)
 {
-	float speed				= CalcMotionSpeed(anm_name_b);
-
 	R_ASSERT				(strstr(anm_name_b.c_str(),"anm_")==anm_name_b.c_str());
 	string256				anim_name_r;
 	bool is_16x9			= UI().is_widescreen();
@@ -323,6 +329,7 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
 	
 	rnd_idx					= (u8)Random.randI(anm->m_animations.size()) ;
 	const motion_descr& M	= anm->m_animations[ rnd_idx ];
+	float speed				= anm->m_anim_speed;
 
 	u32 ret					= g_player_hud->anim_play(m_attach_place_idx, M.mid, bMixIn, md, speed);
 	

--- a/code/engine.vc2008/xrGame/player_hud.h
+++ b/code/engine.vc2008/xrGame/player_hud.h
@@ -20,6 +20,7 @@ struct player_hud_motion
 	shared_str				m_alias_name;
 	shared_str				m_base_name;
 	shared_str				m_additional_name;
+	float					m_anim_speed;
 	xr_vector<motion_descr>	m_animations;
 };
 


### PR DESCRIPTION
- Added 3rd parameter to hud motions - speed multiplier

Useful when you want to balance your weapons properly taking reload/draw/holster animation speeds into account, without need to modify the source animation.

Example usage (in hud section):
```
anm_add_cartridge                      = spas12_reload,, 1.5  ; 50% faster reload
```

Another example:
```
anm_show_16x9			= dev_detector_1_draw_ws, dev_detector_1_draw, 2.0
```