### PR TITLE
Fixes to how launchers fire their grenades + more upgradable params

### DIFF
--- a/code/engine.vc2008/xrGame/WeaponRG6.h
+++ b/code/engine.vc2008/xrGame/WeaponRG6.h
@@ -16,8 +16,11 @@ public:
 	virtual void	Load					(LPCSTR section);
 	virtual void	OnEvent					(NET_Packet& P, u16 type);
 protected:
-	virtual void	FireStart				();
 	virtual u8		AddCartridge			(u8 cnt);
+	virtual	void	FireTrace				(const Fvector& P, const Fvector& D);
+	virtual void	LaunchGrenade			(const Fvector& P, const Fvector& D);
+
+			bool install_upgrade_impl(LPCSTR section, bool test) override;
 
 	DECLARE_SCRIPT_REGISTER_FUNCTION
 };

--- a/code/engine.vc2008/xrGame/WeaponRPG7.h
+++ b/code/engine.vc2008/xrGame/WeaponRPG7.h
@@ -22,16 +22,16 @@ public:
 	virtual	void FireTrace		(const Fvector& P, const Fvector& D);
 	virtual void on_a_hud_attach();
 
-	virtual void FireStart		();
-	virtual void SwitchState	(u32 S);
-
 			void UpdateMissileVisibility	();
 	virtual void UnloadMagazine				(bool spawn_ammo = true);
 
 	virtual void net_Import			( NET_Packet& P);				// import from server
 protected:
-	virtual bool	AllowBore		();
-	virtual void	PlayAnimReload	();
+	virtual void LaunchGrenade	(const Fvector& P, const Fvector& D);
+	virtual bool AllowBore		();
+	virtual void PlayAnimReload	();
+	
+			bool install_upgrade_impl(LPCSTR section, bool test) override;
 
 	shared_str	m_sRocketSection;
 


### PR DESCRIPTION
- RG6 & RPG7: different way to launch grenades from FireTrace function, prevents bug when rocket/grenade is created BEFORE the firing effect (due to how shots are delayed when rpm is low enough)
- lauch_speed is upgradable for RG6 and RPG7