### PR TITLE
Fix crash when calling effector.finish script function after effector.start

### DIFF
--- a/code/engine.vc2008/xrGame/script_effector_script.cpp
+++ b/code/engine.vc2008/xrGame/script_effector_script.cpp
@@ -69,7 +69,7 @@ void CScriptEffector::script_register(lua_State *L)
 		class_<CScriptEffector, CScriptEffectorWrapper>("effector")
 			.def(								constructor<int,float>())
 			.def("start",						&add_effector, adopt<1>())
-			.def("finish",						&remove_effector, adopt<1>())
+			.def("finish",						&remove_effector)
 			.def("process",	 					&CScriptEffector::process,	&CScriptEffectorWrapper::process_static)
 	];
 }


### PR DESCRIPTION
Removed adopt policy from effector.finish script function (this police was only needed in "start" because it transfers ownership of the effector to the engine, but "finish" doesn't need to change ownership anymore... looks like simple oversight from GSC)

PS: this bug was present in ShoC and is still present in CoP :)